### PR TITLE
add LUA_NUMBER_DOUBLE to luaconf.h.in

### DIFF
--- a/liblua/include/luaconf.h.in
+++ b/liblua/include/luaconf.h.in
@@ -45,6 +45,8 @@
 
 /* Type used for numbers in Lua. */
 #define LUA_NUMBER double
+/* Signal to C libraries that LUA_NUMBER is double. */
+#define LUA_NUMBER_DOUBLE
 /* Type used for integers in the Lua C API. */
 #define LUA_INTEGER ptrdiff_t
 /* Result of a `usual argument conversion' over lua_Number. */


### PR DESCRIPTION
This symbol was dropped in f0ab52c83c3f9dde096d26dbf9b071b000937fb2. It is used at least by luabitop, which otherwise builds fine against stock Lua 5.1.